### PR TITLE
Improve display of method nodes

### DIFF
--- a/src/ILSpy.Host/Providers/CecilExtensions.cs
+++ b/src/ILSpy.Host/Providers/CecilExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Mono.Cecil;
+﻿using System.Text;
+using Mono.Cecil;
 
 namespace ILSpy.Host.Providers
 {
@@ -26,6 +27,35 @@ namespace ILSpy.Host.Providers
             return MemberSubKind.None;
         }
 
+        public static string GetFormattedText(this MethodDefinition method)
+        {
+            StringBuilder b = new StringBuilder();
+            b.Append(method.Name);
+            b.Append('(');
+            for (int i = 0; i < method.Parameters.Count; i++)
+            {
+                if (i > 0)
+                    b.Append(", ");
+                b.Append(method.Parameters[i].ParameterType.Name);
+            }
+            if (method.CallingConvention == MethodCallingConvention.VarArg)
+            {
+                if (method.HasParameters)
+                    b.Append(", ");
+                b.Append("...");
+            }
+            if (method.IsConstructor)
+            {
+                b.Append(')');
+            }
+            else
+            {
+                b.Append(") : ");
+                b.Append(method.ReturnType.Name);
+            }
+
+            return b.ToString();
+        }
 
         public static string GetPlatformDisplayName(this ModuleDefinition module)
         {

--- a/src/ILSpy.Host/Providers/CecilExtensions.cs
+++ b/src/ILSpy.Host/Providers/CecilExtensions.cs
@@ -30,7 +30,7 @@ namespace ILSpy.Host.Providers
         public static string GetFormattedText(this MethodDefinition method)
         {
             StringBuilder b = new StringBuilder();
-            b.Append(method.Name);
+            b.Append(method.IsConstructor ? method.DeclaringType.Name : method.Name);
             b.Append('(');
             for (int i = 0; i < method.Parameters.Count; i++)
             {

--- a/src/ILSpy.Host/Providers/SimpleDecompilationProvider.cs
+++ b/src/ILSpy.Host/Providers/SimpleDecompilationProvider.cs
@@ -106,22 +106,27 @@ namespace ILSpy.Host.Providers
                             Token = cecilType.MetadataToken,
                             MemberSubKind = cecilType.GetMemberSubKind()
                         };
-                    }
-                    ).Union(
-                c.Members.Select(m =>
+                    })
+                    .Union(c.Fields.Select(GetMemberData))
+                    .Union(c.Properties.Select(GetMemberData))
+                    .Union(c.Events.Select(GetMemberData))
+                    .Union(c.Methods.Select(GetMemberData));
+
+            MemberData GetMemberData(IMember member)
+            {
+                var cecilRef = dc.TypeSystem.GetCecil(member);
+                var memberName = member is IMethod
+                    ? ((MethodDefinition)cecilRef.Resolve()).GetFormattedText()
+                    : member.Name;
+                return new MemberData
                 {
-                    var cecilRef = dc.TypeSystem.GetCecil(m);
-                    var memberName = m is IMethod
-                        ? ((MethodDefinition)cecilRef.Resolve()).GetFormattedText()
-                        : m.Name;
-                    return new MemberData
-                    {
-                        Name = memberName,
-                        Token = cecilRef.MetadataToken,
-                        MemberSubKind = MemberSubKind.None
-                    };
-                }));
+                    Name = memberName,
+                    Token = cecilRef.MetadataToken,
+                    MemberSubKind = MemberSubKind.None
+                };
+            }
         }
+
 
         public string GetCode(string assemblyPath, TokenType tokenType, uint rid)
         {

--- a/src/ILSpy.Host/Providers/SimpleDecompilationProvider.cs
+++ b/src/ILSpy.Host/Providers/SimpleDecompilationProvider.cs
@@ -259,7 +259,8 @@ namespace ILSpy.Host.Providers
                 var ns = t.Namespace;
                 return ns;
             })
-            .Distinct();
+            .Distinct()
+            .OrderBy(n => n);
 
             return namespaces;
         }

--- a/src/ILSpy.Host/Providers/SimpleDecompilationProvider.cs
+++ b/src/ILSpy.Host/Providers/SimpleDecompilationProvider.cs
@@ -111,9 +111,12 @@ namespace ILSpy.Host.Providers
                 c.Members.Select(m =>
                 {
                     var cecilRef = dc.TypeSystem.GetCecil(m);
+                    var memberName = m is IMethod
+                        ? ((MethodDefinition)cecilRef.Resolve()).GetFormattedText()
+                        : m.Name;
                     return new MemberData
                     {
-                        Name = m.Name,
+                        Name = memberName,
                         Token = cecilRef.MetadataToken,
                         MemberSubKind = MemberSubKind.None
                     };

--- a/test/ILSpy.Host.Tests/DecompilationProviderTests.cs
+++ b/test/ILSpy.Host.Tests/DecompilationProviderTests.cs
@@ -112,7 +112,7 @@ namespace ILSpy.Host.Tests
             var members = provider.GetChildren(assemblyPath, type.Token.TokenType, type.Token.RID);
 
             Assert.NotEmpty(members);
-            var m1 = members.Single(m => m.Name.Equals(".ctor(Int32)"));
+            var m1 = members.Single(m => m.Name.Equals("C(Int32)"));
             Assert.Equal(TokenType.Method, m1.Token.TokenType);
 
             var m2 = members.Single(m => m.Name.Equals("_ProgId"));
@@ -142,7 +142,7 @@ namespace ILSpy.Host.Tests
 
             // Assert
             Assert.NotEmpty(members);
-            var m1 = members.Single(m => m.Name.Equals(".ctor(Int32)"));
+            var m1 = members.Single(m => m.Name.Equals("C(Int32)"));
             var decompiled = provider.GetMemberCode(assemblyPath, m1.Token);
             Assert.Equal(@"public C(int ProgramId)
 {

--- a/test/ILSpy.Host.Tests/DecompilationProviderTests.cs
+++ b/test/ILSpy.Host.Tests/DecompilationProviderTests.cs
@@ -112,7 +112,7 @@ namespace ILSpy.Host.Tests
             var members = provider.GetChildren(assemblyPath, type.Token.TokenType, type.Token.RID);
 
             Assert.NotEmpty(members);
-            var m1 = members.Single(m => m.Name.Equals(".ctor"));
+            var m1 = members.Single(m => m.Name.Equals(".ctor(Int32)"));
             Assert.Equal(TokenType.Method, m1.Token.TokenType);
 
             var m2 = members.Single(m => m.Name.Equals("_ProgId"));
@@ -142,7 +142,7 @@ namespace ILSpy.Host.Tests
 
             // Assert
             Assert.NotEmpty(members);
-            var m1 = members.Single(m => m.Name.Equals(".ctor"));
+            var m1 = members.Single(m => m.Name.Equals(".ctor(Int32)"));
             var decompiled = provider.GetMemberCode(assemblyPath, m1.Token);
             Assert.Equal(@"public C(int ProgramId)
 {

--- a/test/ILSpy.Host.Tests/IntegrationTests.cs
+++ b/test/ILSpy.Host.Tests/IntegrationTests.cs
@@ -98,7 +98,7 @@ namespace ILSpy.Host.Tests
 
             Assert.NotEmpty(data2.Members);
 
-            var m1 = data2.Members.Single(t => t.Name.Equals(".ctor"));
+            var m1 = data2.Members.Single(t => t.Name.Equals(".ctor(Int32)"));
             Assert.Equal(MemberSubKind.None, m1.MemberSubKind);
             Assert.Equal(TokenType.Method, m1.Token.TokenType);
 

--- a/test/ILSpy.Host.Tests/IntegrationTests.cs
+++ b/test/ILSpy.Host.Tests/IntegrationTests.cs
@@ -98,7 +98,7 @@ namespace ILSpy.Host.Tests
 
             Assert.NotEmpty(data2.Members);
 
-            var m1 = data2.Members.Single(t => t.Name.Equals(".ctor(Int32)"));
+            var m1 = data2.Members.Single(t => t.Name.Equals("C(Int32)"));
             Assert.Equal(MemberSubKind.None, m1.MemberSubKind);
             Assert.Equal(TokenType.Method, m1.Token.TokenType);
 

--- a/test/TestAssembly/C.cs
+++ b/test/TestAssembly/C.cs
@@ -27,6 +27,10 @@ namespace TestAssembly
             }
         }
 
+        static C() { }
+
+        public C() { }
+
         /// <summary>
         /// Some class ctor
         /// </summary>


### PR DESCRIPTION
**Use formated text for method name**
This will differentiate names of method overloads

**Group members by their types**
in the order of field, property, event, methods

Also show .ctor and ..ctor using their declaring type names